### PR TITLE
Add note about Blheli_32 support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This software is provided as is, use it at your own risk. **ALWAYS REMOVE THE PR
 
 * Only BLHeli passthrough supported at the moment, hence only **CleanFlight**,  **BetaFlight**, **INAV** and **TriFlight**
 * Changing settings for any BLHeli_S, BLHeli SiLabs and BLHeli Atmel ESCs with bootloader
-* Flashing BLHeli and BLHeli_S to SiLabs and Atmel ESCs
+* Flashing BLHeli and BLHeli_S to SiLabs and Atmel ESCs (*BLheli_32 **NOT** supported*)
 
 ## Future plans
 


### PR DESCRIPTION
Wasn't clear to me until reading [this](https://www.reddit.com/r/Multicopter/comments/72r9u6/blheli_configurator_isnt_showing_anything_when_i/). I figure it is good to explicitly say it.