### PR TITLE
Read setup when flash finished

### DIFF
--- a/jsx/blheli_configurator.jsx
+++ b/jsx/blheli_configurator.jsx
@@ -391,6 +391,9 @@ var Configurator = React.createClass({
             } catch (error) {
                 GUI.log(chrome.i18n.getMessage('writeSetupFailed', [ error.message ]));
             }
+
+            // read settings back
+            await self.readSetup();
         } else {
             GUI.log('Will not write settings back due to different MODE\n');
 


### PR DESCRIPTION
Trying to make the flashing more consistent, if we don't read after flashing, many values can be seen to be corrupted in some cases. I'm not totally sure if we should do the read setup at this point or another