### PR TITLE
Add show log text when log is not already open

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,6 +135,8 @@ $(document).ready(function () {
     chrome.storage.local.get('logopen', function (result) {
         if (result.logopen) {
             $("#showlog").trigger('click');
+         } else {
+            $("#showlog").text(chrome.i18n.getMessage('showLog'));
          }
     });
 


### PR DESCRIPTION
The "Show log" does not display and the button cannot be pressed when the log state is not already opened.