### PR TITLE
Do not allow flashing simultaneously

### DIFF
--- a/jsx/blheli_configurator.jsx
+++ b/jsx/blheli_configurator.jsx
@@ -869,6 +869,10 @@ var Configurator = React.createClass({
         });
     },
     flashAll: async function(hex, eep) {
+        if (this.state.isFlashing) {
+            return console.warn('Flashing is already in progress!')
+        }
+
         $('a.connect').addClass('disabled');
 
         this.setState({ isFlashing: true });


### PR DESCRIPTION
It is possible to click the `Flash` button multiple times, especially when the hex file has not been cached - which results in corruption and potentially bricks the ESC.