### PR TITLE
Modify the W and Z layout cannot load the firmware.

### DIFF
--- a/js/blheli_versions.json
+++ b/js/blheli_versions.json
@@ -7,7 +7,7 @@
 		},
 		{
 			"name": "16.7 [Official]",
-			"url": "https://raw.githubusercontent.com/bitdump/BLHeli/0586df7a16b46775fc9e6dad0316959bb36d4e1e/BLHeli_S SiLabs/Hex files/{0}_REV16_7.HEX",
+			"url": "https://raw.githubusercontent.com/bitdump/BLHeli/db370a8779787ed2c5ee8a3f049904f6cc8e5453/BLHeli_S SiLabs/Hex files/{0}_REV16_7.HEX",
 			"key": "16.7"
 		},
 		{


### PR DESCRIPTION
This BLHeli_S_16.7 Commits (0586df7a16b46775fc9e6dad0316959bb36d4e1e) does not contain Hex files corresponding to W and Z layouts. Should be replaced with e476c460aaadb2e543db408b7c29bd608b7c29bd6.